### PR TITLE
Handle socket disposed

### DIFF
--- a/src/SolarWind/Channel.cs
+++ b/src/SolarWind/Channel.cs
@@ -238,6 +238,9 @@ namespace Codestellation.SolarWind
             }
             catch (OperationCanceledException)
             {
+                //Return buffers in case of work finished.
+                Array.ForEach(_batch, m => m.Dispose());
+                Array.Clear(_batch, 0, _batch.Length);
                 _logger.LogInformation("Send worker stopped");
             }
         }

--- a/src/SolarWind/Internals/Connection.cs
+++ b/src/SolarWind/Internals/Connection.cs
@@ -48,7 +48,7 @@ namespace Codestellation.SolarWind.Internals
             }
             catch (ObjectDisposedException e)
             {
-                throw new IOException("Reveive faild", e);
+                throw new IOException("Receive failed", e);
             }
         }
 
@@ -63,7 +63,7 @@ namespace Codestellation.SolarWind.Internals
             }
             catch (ObjectDisposedException e)
             {
-                throw new IOException("Reveive faild", e);
+                throw new IOException("Receive failed", e);
             }
         }
 


### PR DESCRIPTION
Fixes two issues:
 * Handle `ObjectDisposedException` during send operations
 * Fixed race conditions on reconnect when batch could be used by multiples threads

