### PR TITLE
Added logs to catch the deserialization error

### DIFF
--- a/src/SolarWind/Channel.cs
+++ b/src/SolarWind/Channel.cs
@@ -150,13 +150,14 @@ namespace Codestellation.SolarWind
                 WireHeader wireHeader = WireHeader.ReadFrom(buffer);
                 buffer.Reset();
 
-                await _connection.ReceiveAsync(buffer, wireHeader.PayloadSize.Value, token).ConfigureAwait(ContinueOn.IOScheduler);
+                int payloadSize = wireHeader.PayloadSize.Value;
+                await _connection.ReceiveAsync(buffer, payloadSize, token).ConfigureAwait(ContinueOn.IOScheduler);
                 buffer.Position = 0;
                 var message = new Message(wireHeader.MessageHeader, buffer);
 
                 if (_logger.IsEnabled(LogLevel.Debug))
                 {
-                    _logger.LogDebug($"Received {message.Header.ToString()}");
+                    _logger.LogDebug($"Received {message.Header.ToString()} size={payloadSize}");
                 }
                 _session.EnqueueIncoming(message);
                 _lastReceived = DateTime.Now.Ticks;

--- a/src/SolarWind/Internals/Connection.cs
+++ b/src/SolarWind/Internals/Connection.cs
@@ -88,14 +88,17 @@ namespace Codestellation.SolarWind.Internals
         {
             try
             {
+                PooledMemoryStream payload = message.Payload;
+                long payloadLength = payload.Length;
+
                 if (_logger.IsEnabled(LogLevel.Debug))
                 {
-                    _logger.LogDebug($"Writing message {message.Header.ToString()}");
+                    _logger.LogDebug($"Writing message {message.Header.ToString()} size={payloadLength}");
                 }
 
                 var available = _writeBuffer.Length - _writePosition;
-                PooledMemoryStream payload = message.Payload;
-                var wireHeader = new WireHeader(message.Header, new PayloadSize((int)payload.Length));
+                var payloadSize = new PayloadSize((int)payloadLength);
+                var wireHeader = new WireHeader(message.Header, payloadSize);
 
                 if (available < WireHeader.Size)
                 {
@@ -105,7 +108,7 @@ namespace Codestellation.SolarWind.Internals
                 WireHeader.WriteTo(in wireHeader, _writeBuffer, _writePosition);
                 _writePosition += WireHeader.Size;
 
-                var bytesToSend = (int)payload.Length;
+                var bytesToSend = (int)payloadLength;
                 payload.Position = 0;
                 while (bytesToSend > 0)
                 {

--- a/src/SolarWind/Internals/Session.cs
+++ b/src/SolarWind/Internals/Session.cs
@@ -120,17 +120,21 @@ namespace Codestellation.SolarWind.Internals
                 for (var i = 0; i < batchLength; i++)
                 {
                     Message incoming = batch[i];
+                    PooledMemoryStream payload = incoming.Payload;
+                    long position = payload.Position;
+                    long length = payload.Length;
+
                     object data;
                     try
                     {
-                        data = _serializer.Deserialize(incoming.Header, incoming.Payload);
+                        data = _serializer.Deserialize(incoming.Header, payload);
                         incoming.Dispose();
                     }
                     catch (Exception ex)
                     {
                         if (_logger.IsEnabled(LogLevel.Error))
                         {
-                            _logger.LogError(ex, $"Deserialization failure. {incoming.Header.ToString()}");
+                            _logger.LogError(ex, $"Deserialization failure: position={position} length={length} offset={payload.Position} header={incoming.Header.ToString()}");
                         }
 
                         incoming.Dispose();


### PR DESCRIPTION
Добавил логов в попытке поймать ошибку десериализации.
```
11:23:12:0422 DEBUG Channel: Received TypeId=280; MsgId=946626148 
11:23:12:0422 ERROR Session: Deserialization failure. TypeId=280; MsgId=946626148 ProtoBuf.ProtoException: Invalid wire-type; this usually means you have over-written a file without truncating or setting the length; see https://stackoverflow.com/q/2152978/23354
   at ProtoBuf.ProtoReader.ReadDouble() in D:\Projects\protobuf-net\src\protobuf-net\ProtoReader.cs:line 582
   at proto_40(Object, ProtoReader)
   at proto_38(Object, ProtoReader)
   at proto_34(Object, ProtoReader)
   at proto_32(Object, ProtoReader)
   at ProtoBuf.Meta.TypeModel.DeserializeCore(ProtoReader reader, Type type, Object value, Boolean noAutoCreate)
   at ProtoBuf.Meta.TypeModel.Deserialize(Stream source, Object value, Type type, SerializationContext context)
   at Foo.DeserializeResponse(MessageTypeId typeId, Stream stream)
   at Codestellation.SolarWind.Internals.Session.StartDeserializationTask()

```